### PR TITLE
Small-molecule RL: run infra, reward variants (acq max/mean + ΔHV), 9B launchers, and PR #2 fixes

### DIFF
--- a/rl/ldm_rl/env.py
+++ b/rl/ldm_rl/env.py
@@ -47,7 +47,7 @@ from ldm_tts.optimization.records import (
 from ldm_rl.parsing import call_text_parser, load_declared_parser
 from ldm_rl.prompts import render_reset_observation, render_step_observation
 
-REWARD_POLICIES = ("improvement", "raw", "binary", "acquisition")
+REWARD_POLICIES = ("improvement", "raw", "binary", "acquisition", "hypervolume")
 ACQUISITION_AGGS = ("max", "mean")
 
 
@@ -68,6 +68,7 @@ class EnvConfig:
     reward_failure: float = 0.0
     reward_invalid: float = 0.0
     acquisition_agg: str = "max"
+    reward_ref_point: tuple[float, ...] | None = None
 
     def __post_init__(self) -> None:
         if self.iterations < 0:
@@ -590,6 +591,9 @@ class LDMEnv:
         if self.config.reward == "acquisition":
             return self._acquisition_reward(new_observations, selection, components)
 
+        if self.config.reward == "hypervolume":
+            return self._hypervolume_reward(new_observations, components)
+
         new_values = [self._oriented(item.metrics) for item in succeeded]
         after = tuple(max(values[i] for values in new_values) for i in range(len(self.objectives.specs)))
 
@@ -649,6 +653,95 @@ class LDMEnv:
         value = sum(scores) / len(scores) if agg == "mean" else max(scores)
         components.update({"kind": "acquisition", "scores": scores, "agg": agg})
         return value, components
+
+    @staticmethod
+    def _hypervolume_2d(
+        points: Sequence[tuple[float, float]], ref: tuple[float, float]
+    ) -> float:
+        """Dominated hypervolume of a 2-objective (maximise) point set vs ``ref``.
+
+        ``ref`` is the lower-left reference corner in oriented space; only points
+        that strictly dominate it contribute.
+        """
+
+        rx, ry = ref
+        pts = [(a, b) for (a, b) in points if a > rx and b > ry]
+        if not pts:
+            return 0.0
+        # Pareto front: scan by x descending, keep strictly increasing y.
+        pts.sort(key=lambda p: (-p[0], -p[1]))
+        front: list[tuple[float, float]] = []
+        best_y = float("-inf")
+        for a, b in pts:
+            if b > best_y:
+                front.append((a, b))
+                best_y = b
+        front.reverse()  # -> x ascending, y descending
+        hv = 0.0
+        prev_x = rx
+        for a, b in front:
+            hv += (a - prev_x) * (b - ry)
+            prev_x = a
+        return hv
+
+    def _hypervolume_reward(
+        self,
+        new_observations: Sequence[Observation],
+        components: dict[str, Any],
+    ) -> tuple[float, dict[str, Any]]:
+        """Per-round Pareto-front hypervolume improvement from real outcomes.
+
+        Reward = HV(front after this round) - HV(front before), clipped at 0.
+        Uses measured objective values (unlike ``acquisition``), so it directly
+        rewards how much the round pushed the observed Pareto front. Two
+        objectives only; ``reward_ref_point`` (oriented space) fixes the
+        reference, else a per-round nadir is used consistently for before/after.
+        """
+
+        if len(self.objectives.specs) != 2:
+            raise ValueError(
+                "hypervolume reward supports exactly 2 objectives, got "
+                f"{len(self.objectives.specs)}"
+            )
+        new_ids = {id(o) for o in new_observations}
+        all_obs = list(self._state.observations)  # already includes this round
+        prior = [o for o in all_obs if id(o) not in new_ids]
+
+        def pts(observations: Sequence[Observation]) -> list[tuple[float, float]]:
+            out: list[tuple[float, float]] = []
+            for o in observations:
+                if o.evaluation.succeeded:
+                    v = self._oriented(o.metrics)
+                    out.append((float(v[0]), float(v[1])))
+            return out
+
+        after_pts = pts(all_obs)
+        before_pts = pts(prior)
+        if self.config.reward_ref_point is not None:
+            ref = (
+                float(self.config.reward_ref_point[0]),
+                float(self.config.reward_ref_point[1]),
+            )
+        elif after_pts:
+            eps = 1e-6
+            ref = (
+                min(p[0] for p in after_pts) - eps,
+                min(p[1] for p in after_pts) - eps,
+            )
+        else:
+            ref = (0.0, 0.0)
+        hv_after = self._hypervolume_2d(after_pts, ref)
+        hv_before = self._hypervolume_2d(before_pts, ref)
+        dhv = max(0.0, hv_after - hv_before)
+        components.update(
+            {
+                "kind": "hypervolume",
+                "hv_before": hv_before,
+                "hv_after": hv_after,
+                "ref_point": ref,
+            }
+        )
+        return dhv, components
 
     # ------------------------------------------------------------------- run
 

--- a/rl/ldm_rl/env.py
+++ b/rl/ldm_rl/env.py
@@ -48,6 +48,7 @@ from ldm_rl.parsing import call_text_parser, load_declared_parser
 from ldm_rl.prompts import render_reset_observation, render_step_observation
 
 REWARD_POLICIES = ("improvement", "raw", "binary", "acquisition")
+ACQUISITION_AGGS = ("max", "mean")
 
 
 @dataclass(frozen=True)
@@ -66,6 +67,7 @@ class EnvConfig:
     reward: str = "improvement"
     reward_failure: float = 0.0
     reward_invalid: float = 0.0
+    acquisition_agg: str = "max"
 
     def __post_init__(self) -> None:
         if self.iterations < 0:
@@ -108,6 +110,11 @@ class EnvConfig:
         if self.reward not in REWARD_POLICIES:
             raise ValueError(
                 f"unknown reward policy {self.reward!r}; expected one of {REWARD_POLICIES}"
+            )
+        if self.acquisition_agg not in ACQUISITION_AGGS:
+            raise ValueError(
+                f"unknown acquisition_agg {self.acquisition_agg!r}; "
+                f"expected one of {ACQUISITION_AGGS}"
             )
 
 
@@ -636,9 +643,12 @@ class LDMEnv:
         if not scores:
             components["kind"] = "acquisition"
             components["scores"] = []
+            components["agg"] = self.config.acquisition_agg
             return 0.0, components
-        components.update({"kind": "acquisition", "scores": scores})
-        return max(scores), components
+        agg = self.config.acquisition_agg
+        value = sum(scores) / len(scores) if agg == "mean" else max(scores)
+        components.update({"kind": "acquisition", "scores": scores, "agg": agg})
+        return value, components
 
     # ------------------------------------------------------------------- run
 

--- a/rl/ldm_rl/episodes.py
+++ b/rl/ldm_rl/episodes.py
@@ -44,6 +44,7 @@ class EpisodeSpec:
     reward_failure: float = 0.0
     reward_invalid: float = 0.0
     acquisition_agg: str = "max"
+    reward_ref_point: tuple[float, ...] | None = None
     max_empty_reservoir_rounds: int = 3
     target_observations: int | None = None
     target_successful_evaluations: int | None = None
@@ -79,6 +80,7 @@ class EpisodeSpec:
             reward_failure=self.reward_failure,
             reward_invalid=self.reward_invalid,
             acquisition_agg=self.acquisition_agg,
+            reward_ref_point=self.reward_ref_point,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -102,6 +104,7 @@ class EpisodeSpec:
             reward_failure=self.reward_failure,
             reward_invalid=self.reward_invalid,
             acquisition_agg=self.acquisition_agg,
+            reward_ref_point=self.reward_ref_point,
         )
 
     @classmethod
@@ -116,6 +119,7 @@ class EpisodeSpec:
             "reward_failure",
             "reward_invalid",
             "acquisition_agg",
+            "reward_ref_point",
             "max_empty_reservoir_rounds",
             "target_observations",
             "target_successful_evaluations",
@@ -169,6 +173,14 @@ def main(argv: list[str] | None = None) -> int:
         default="max",
         help="How to aggregate per-round acquisition scores when reward=acquisition.",
     )
+    parser.add_argument(
+        "--reward-ref-point",
+        default="",
+        help=(
+            "Comma-separated oriented-space reference point for reward=hypervolume "
+            "(e.g. '0,5'); empty -> per-round nadir."
+        ),
+    )
     parser.add_argument("--seed-offset", type=int, default=0)
     parser.add_argument(
         "--real-kwargs",
@@ -192,6 +204,13 @@ def main(argv: list[str] | None = None) -> int:
             parser.error("--real-kwargs must decode to a JSON object")
         real_kwargs = dict(parsed)
 
+    ref_point: tuple[float, ...] | None = None
+    if args.reward_ref_point.strip():
+        try:
+            ref_point = tuple(float(x) for x in args.reward_ref_point.split(","))
+        except ValueError:
+            parser.error("--reward-ref-point must be comma-separated floats, e.g. '0,5'")
+
     rows = make_prompt_rows(
         [
             EpisodeSpec(
@@ -202,6 +221,7 @@ def main(argv: list[str] | None = None) -> int:
                 evaluations_per_round=args.evaluations_per_round,
                 reward=args.reward,
                 acquisition_agg=args.acquisition_agg,
+                reward_ref_point=ref_point,
                 seed=args.seed_offset + index,
                 real=real_kwargs,
             )

--- a/rl/ldm_rl/episodes.py
+++ b/rl/ldm_rl/episodes.py
@@ -28,7 +28,7 @@ if __package__ in (None, ""):
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
-from ldm_rl.env import EnvConfig, REWARD_POLICIES
+from ldm_rl.env import ACQUISITION_AGGS, EnvConfig, REWARD_POLICIES
 
 
 @dataclass(frozen=True)
@@ -43,6 +43,7 @@ class EpisodeSpec:
     reward: str = "improvement"
     reward_failure: float = 0.0
     reward_invalid: float = 0.0
+    acquisition_agg: str = "max"
     max_empty_reservoir_rounds: int = 3
     target_observations: int | None = None
     target_successful_evaluations: int | None = None
@@ -77,6 +78,7 @@ class EpisodeSpec:
             reward=self.reward,
             reward_failure=self.reward_failure,
             reward_invalid=self.reward_invalid,
+            acquisition_agg=self.acquisition_agg,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -99,6 +101,7 @@ class EpisodeSpec:
             reward=self.reward,
             reward_failure=self.reward_failure,
             reward_invalid=self.reward_invalid,
+            acquisition_agg=self.acquisition_agg,
         )
 
     @classmethod
@@ -112,6 +115,7 @@ class EpisodeSpec:
             "reward",
             "reward_failure",
             "reward_invalid",
+            "acquisition_agg",
             "max_empty_reservoir_rounds",
             "target_observations",
             "target_successful_evaluations",
@@ -159,6 +163,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--reward", choices=REWARD_POLICIES, default="improvement"
     )
+    parser.add_argument(
+        "--acquisition-agg",
+        choices=ACQUISITION_AGGS,
+        default="max",
+        help="How to aggregate per-round acquisition scores when reward=acquisition.",
+    )
     parser.add_argument("--seed-offset", type=int, default=0)
     parser.add_argument(
         "--real-kwargs",
@@ -191,6 +201,7 @@ def main(argv: list[str] | None = None) -> int:
                 reservoir_size=args.reservoir_size,
                 evaluations_per_round=args.evaluations_per_round,
                 reward=args.reward,
+                acquisition_agg=args.acquisition_agg,
                 seed=args.seed_offset + index,
                 real=real_kwargs,
             )

--- a/rl/ldm_rl/examples/small_molecule_real_smoke.py
+++ b/rl/ldm_rl/examples/small_molecule_real_smoke.py
@@ -1,0 +1,88 @@
+"""Real-evaluation smoke test for the small-molecule env (CPU only).
+
+Drives a few real rounds — real AutoDock Vina docking + activity NN + GP/SIR
+selection — with a scripted proposer, and prints the per-round real metrics and
+reward. This exercises the REAL path (not mock), including the acquisition and
+hypervolume reward policies. No GPU needed.
+
+Usage (inside the image / any env with the small-molecule real deps + vina):
+    python small_molecule_real_smoke.py [rounds] [reward]
+      rounds : number of rounds (default 3)
+      reward : improvement | acquisition | hypervolume (default hypervolume)
+
+Point VINA_BIN / NN_MODEL to real artifacts, or rely on the defaults below.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_RL_ROOT = Path(__file__).resolve().parents[2]
+for _p in (_RL_ROOT, _REPO_ROOT):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+from ldm_rl import EnvConfig  # noqa: E402
+from ldm_rl.factories import build_env  # noqa: E402
+from tasks.small_molecule.core.workflow import ExpandingMockCase2LLM  # noqa: E402
+
+
+def main() -> int:
+    rounds = int(sys.argv[1]) if len(sys.argv) > 1 else 3
+    reward = sys.argv[2] if len(sys.argv) > 2 else "hypervolume"
+
+    real_kwargs = dict(
+        vina_bin=os.environ.get("VINA_BIN", "/mnt/data0/dock-project/bin/vina"),
+        nn_model_path=os.environ.get(
+            "NN_MODEL",
+            str(_REPO_ROOT / "tasks/small_molecule/resources/models/best_g12d_model.joblib"),
+        ),
+        vina_pdb_id="8UN5",
+        vina_chain_id="A",
+        gp_device="cpu",
+        vina_exhaustiveness=1,
+        vina_n_poses=1,
+        vina_max_workers=1,
+    )
+    print(f"[real-smoke] reward={reward} rounds={rounds} vina={real_kwargs['vina_bin']}", flush=True)
+
+    env = build_env(
+        "small_molecule",
+        mode="real",
+        config=EnvConfig(
+            iterations=rounds,
+            reservoir_size=2,
+            evaluations_per_round=1,
+            reward=reward,
+        ),
+        **real_kwargs,
+    )
+    llm = ExpandingMockCase2LLM()
+
+    obs = env.reset()
+    total = 0.0
+    for r in range(rounds):
+        action = llm.chat("system", obs, json_mode=True)
+        step = env.step(action)
+        total += step.reward
+        ev = step.info.get("evaluated") or []
+        metrics = ev[0]["evaluation"]["metrics"] if ev else {}
+        print(
+            f"round={r} reward={step.reward:.6f} kind={step.info['reward_components'].get('kind')} "
+            f"metrics={ {k: round(v, 4) for k, v in metrics.items()} } "
+            f"done={step.done}",
+            flush=True,
+        )
+        obs = step.observation
+        if step.done:
+            break
+    print("SMOKE_OK " + json.dumps({"reward": reward, "rounds": rounds, "total_reward": round(total, 6)}), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rl/ldm_rl/tests/test_acquisition_agg.py
+++ b/rl/ldm_rl/tests/test_acquisition_agg.py
@@ -1,0 +1,38 @@
+"""Coverage for the acquisition-score aggregation switch (max / mean)."""
+
+import pytest
+
+from ldm_rl.env import ACQUISITION_AGGS, EnvConfig
+from ldm_rl.episodes import EpisodeSpec
+
+
+def test_default_agg_is_max():
+    assert EnvConfig(iterations=1, reward="acquisition").acquisition_agg == "max"
+
+
+@pytest.mark.parametrize("agg", ACQUISITION_AGGS)
+def test_valid_aggs_accepted(agg):
+    assert EnvConfig(iterations=1, acquisition_agg=agg).acquisition_agg == agg
+
+
+def test_invalid_agg_rejected():
+    with pytest.raises(ValueError):
+        EnvConfig(iterations=1, acquisition_agg="median")
+
+
+def test_agg_threads_through_episode_spec_and_json():
+    spec = EpisodeSpec(
+        task="small_molecule",
+        mode="real",
+        reward="acquisition",
+        acquisition_agg="mean",
+        real={"gp_history_file": "/tmp/gp.jsonl"},
+    )
+    assert spec.to_env_config().acquisition_agg == "mean"
+    assert EpisodeSpec.from_json(spec.to_json()).acquisition_agg == "mean"
+
+
+def test_aggregation_math():
+    scores = [0.2, 0.8, 0.5]
+    assert max(scores) == pytest.approx(0.8)
+    assert sum(scores) / len(scores) == pytest.approx(0.5)

--- a/rl/ldm_rl/tests/test_factories.py
+++ b/rl/ldm_rl/tests/test_factories.py
@@ -127,9 +127,13 @@ def test_small_molecule_mock_episode() -> None:
     assert result.total_reward > 0.0
 
 
-def test_small_molecule_real_mode_raises() -> None:
-    with pytest.raises(ValueError, match="mock mode only"):
-        build_env("small_molecule", mode="real")
+def test_small_molecule_real_mode_is_supported() -> None:
+    # Real mode is wired (tasks.small_molecule.core.rl_real.build_real_components),
+    # so the factory must NOT reject it; only an unknown mode is rejected.
+    from tasks.small_molecule.core.rl_adapter import build_rl_components
+
+    with pytest.raises(ValueError, match="mock and real modes only"):
+        build_rl_components(mode="bogus")
 
 
 def test_causal_discovery_mock_episode() -> None:

--- a/rl/ldm_rl/tests/test_hypervolume_reward.py
+++ b/rl/ldm_rl/tests/test_hypervolume_reward.py
@@ -1,0 +1,52 @@
+"""Coverage for the 2D hypervolume-improvement reward."""
+
+import pytest
+
+from ldm_rl.env import REWARD_POLICIES, EnvConfig, LDMEnv
+from ldm_rl.episodes import EpisodeSpec
+
+
+def test_hypervolume_is_a_policy():
+    assert "hypervolume" in REWARD_POLICIES
+    assert EnvConfig(iterations=1, reward="hypervolume").reward == "hypervolume"
+
+
+def test_hv2d_single_point():
+    assert LDMEnv._hypervolume_2d([(2.0, 2.0)], (0.0, 0.0)) == pytest.approx(4.0)
+
+
+def test_hv2d_two_point_front_with_overlap():
+    # rects [0,2]x[0,1] and [0,1]x[0,2] -> union area 3
+    assert LDMEnv._hypervolume_2d([(2.0, 1.0), (1.0, 2.0)], (0.0, 0.0)) == pytest.approx(3.0)
+
+
+def test_hv2d_dominated_point_ignored():
+    # (1,1) is dominated by (2,2); HV == HV of (2,2) alone
+    assert LDMEnv._hypervolume_2d([(2.0, 2.0), (1.0, 1.0)], (0.0, 0.0)) == pytest.approx(4.0)
+
+
+def test_hv2d_points_below_ref_excluded():
+    assert LDMEnv._hypervolume_2d([(-1.0, 5.0), (5.0, -1.0)], (0.0, 0.0)) == pytest.approx(0.0)
+
+
+def test_hv_improvement_is_nonnegative_and_monotone():
+    # front growing from {(1,1)} to {(1,1),(2,2)} increases HV
+    ref = (0.0, 0.0)
+    before = LDMEnv._hypervolume_2d([(1.0, 1.0)], ref)
+    after = LDMEnv._hypervolume_2d([(1.0, 1.0), (2.0, 2.0)], ref)
+    assert after > before
+    assert max(0.0, after - before) == pytest.approx(after - before)
+
+
+def test_ref_point_threads_through_episode_spec_json():
+    spec = EpisodeSpec(
+        task="small_molecule",
+        mode="real",
+        reward="hypervolume",
+        reward_ref_point=(0.0, 5.0),
+        real={"gp_history_file": "/tmp/gp.jsonl"},
+    )
+    assert tuple(spec.to_env_config().reward_ref_point) == (0.0, 5.0)
+    # JSON round-trip preserves the values (tuple -> list is fine downstream)
+    rt = EpisodeSpec.from_json(spec.to_json())
+    assert tuple(rt.reward_ref_point) == (0.0, 5.0)

--- a/rl/slime_launch/HANDOFF.md
+++ b/rl/slime_launch/HANDOFF.md
@@ -101,7 +101,7 @@ conda activate ldm-rl
 export PYTHONPATH=$LDM/rl/megatron-lm:$LDM/rl:$LDM
 srun bash $LDM/rl/slime_launch/run_train_real_9b.sh
 ```
-每个 run 建议 ≥3–5 seed(`--seed-offset`)。开 wandb: `export WANDB_KEY=<key>`。
+每个 run 建议 ≥3–5 seed:**换环境 seed 要用 `python -m ldm_rl.episodes --seed-offset N` 重新生成 episodes**(`--seed-offset` 是 `episodes.py` 的参数,**不是** slime/训练启动器的;slime 的 `--seed`/`--rollout-seed` 只管框架侧随机性,改了不换环境轨迹)。开 wandb: `export WANDB_KEY=<key>`。
 
 ## 6. 训练计划（分阶段,带验证闸;实验组见 TRAINING_PLAN.md）
 1. **P0**:1.5B 跑通 GRPO,验 **backward(ARM/TE 是否 SIGSEGV)+ docking + reward** 全链路。**这是最先做的闸——TE 装对没对,这一步见分晓。**

--- a/rl/slime_launch/HANDOFF.md
+++ b/rl/slime_launch/HANDOFF.md
@@ -1,0 +1,105 @@
+# 小分子 RL 交接指南（装环境 · 跑 · 训练计划）
+
+从零把 **小分子 acquisition-RL（GRPO on Slime）** 跑起来。运行矩阵见同目录 `RUNS.md`。
+**方向：train KRAS G12D → eval G12C & G12D**（G12D 评测器现成；G12C 只在离线评测时用）。
+
+---
+
+## A. 装环境（最关键，别跳）
+
+> ⚠️ 必须是**配平的 torch 2.11 + 匹配 TE** 栈，否则 GRPO backward 会 SIGSEGV。**强烈建议直接用我们的 Docker 镜像**，不要自己从头 pip 装。
+
+### A1. 代码
+```bash
+git clone --recurse-submodules -b rl https://github.com/YihangChen9/Large-Discovery-Models.git LDM
+cd LDM
+git submodule update --init rl/slime rl/megatron-lm
+cd rl/megatron-lm && git checkout 1dcf0dafa884ad52ffb243625717a3471643e087 && cd ../..
+```
+
+### A2. 环境镜像（三选一，优先第 1）
+1. **能访问镜像仓库** → 直接拉：
+   ```bash
+   docker pull image.yangtzeailab.com/opensandbox/ldm-slime-rl:latest
+   ```
+2. **拿到镜像 tar** → 导入：`gunzip -c ldm-slime-rl.tar.gz | docker load`
+3. **都不行** → 用 `rl/slime/build_conda.sh` 重建（torch 2.11 + TE 2.16.1 + 匹配 megatron/sglang commit），再按 `rl/SLIME_TRAINING.md` 打 6 个 patch。**最容易踩坑，尽量避免。**
+
+镜像里已备：conda env `/root/micromamba/envs/slime`、Megatron `/root/megatron-lm`、torch 2.11+cu129、匹配 TE、rdkit/meeko（docking 用）。
+
+### A3. 起容器（挂代码 + 资产盘 + GPU）
+```bash
+docker run --gpus all -it --shm-size=32g \
+  -v /path/to/LDM:/mnt/data0/ys/LDM \
+  -v /path/to/assets:/mnt/data0 \
+  image.yangtzeailab.com/opensandbox/ldm-slime-rl:latest bash
+```
+> 脚本里的路径都写死在 `/mnt/data0/...`，把资产放到对应位置最省事（见 B）。
+
+---
+
+## B. 资产（放到这些路径）
+
+| 资产 | 路径 | 来源 |
+|---|---|---|
+| base 模型 Qwen3.5-9B | `/mnt/data0/hf_models/models/Qwen3.5-9B` | HF `Qwen/Qwen3.5-9B` |
+| SFT no-GP 模型 | `/mnt/data0/hf_models/models/LDM-CoT-SFT` | HF `Yangtze-ailab/LDM-CoT-SFT-Qwen3.5-9B-MixedScience` |
+| 冒烟 Qwen2.5-1.5B | `/mnt/data0/hf_models/models/Qwen2.5-1.5B-Instruct` | HF |
+| vina 二进制 | `/mnt/data0/dock-project/bin/vina` | 随 assets 包 |
+| G12D 活性模型 | `tasks/small_molecule/resources/models/best_g12d_model.joblib` | **已在 repo** |
+| 8UN5 受体（制备好） | `/mnt/data0/ys/LDM/docking_work/receptors/…` | 随 assets 包 / 或 meeko 从 RCSB 8UN5 重制备 |
+
+下模型：
+```bash
+pip install -U "huggingface_hub[cli]"
+hf download Qwen/Qwen3.5-9B --local-dir /mnt/data0/hf_models/models/Qwen3.5-9B
+hf download Yangtze-ailab/LDM-CoT-SFT-Qwen3.5-9B-MixedScience --local-dir /mnt/data0/hf_models/models/LDM-CoT-SFT
+```
+
+---
+
+## C. 准备（一次）
+```bash
+cd /mnt/data0/ys/LDM/rl/slime_launch
+# 1) 转 Megatron torch_dist（base + SFT 各一次）
+MODEL_HF=/mnt/data0/hf_models/models/Qwen3.5-9B  SAVE=/mnt/data0/ys/LDM/rl/qwen3.5-9B_torch_dist      bash convert_9b.sh
+MODEL_HF=/mnt/data0/hf_models/models/LDM-CoT-SFT SAVE=/mnt/data0/ys/LDM/rl/qwen3.5-9B-sft_torch_dist  bash convert_9b.sh
+# 2) 生成 4 个 run 的 episodes（reward 已烤进数据）
+bash gen_episodes_runs.sh
+# 3) 暖共享 GP（rollout-only，dock warmup.num_samples 个分子）
+bash run_warmup_real_slime.sh
+```
+
+---
+
+## D. 怎么跑（4 个 run，各 4 卡 / TP=2）
+命令全在 **`RUNS.md`**（R1 base·acq-max / R2 SFT·acq-max / R3 SFT·真reward / R4 SFT·acq-mean）。每个 run 建议 **≥3–5 seed** 出误差棒。开 wandb 加 `export WANDB_KEY=<key>`。
+
+---
+
+## E. 训练计划（分阶段，带验证闸）
+
+**P0 — 环境 & backward 验证（1.5B，最便宜，先做这个）**
+用现成 `qwen2.5-1.5B_torch_dist_te` 跑 `run_train_real_shared.sh`（3 卡）。
+✅ 通过标准：GRPO **backward 不 SIGSEGV**、reward/loss 有正常值、走过 ≥5 rollout step、能 `--save`。这一步同时验证 docking + acquisition reward + bridge 全链路。
+
+**P1 — 9B 冒烟（mock，验 hybrid）**
+转好 9B torch_dist 后，把 episodes 改 `--mode mock` 跑 `run_train_real_9b.sh`。
+✅ 通过标准：9B hybrid **backward 能过**、不 OOM、reward 会动。专治"Qwen3.5 hybrid 未验证"。
+
+**P2 — 真训练（4 个 run × seed，real）**
+按 `RUNS.md` 起 R1–R4，全部 **train G12D**。
+- R1 vs R2：base-RL vs SFT-RL（SFT 打底有没有用）
+- R2 vs R3 vs R4：reward 消融（acq-max / 真结果 / acq-mean）
+
+**评测（train D → 测 C & D）**
+取各 run 的 best checkpoint，用离线 eval harness 在 **G12C 和 G12D** 上跑 LDM loop（budget 80，5 seed），比 hypervolume。参照行：base（无RL）、SFT（无RL）。
+> G12C 评测器 = 原 G12C campaign 的 G12C 受体 + G12C 活性模型（论文 G12C 那列跑的那套）。
+
+---
+
+## F. 已知坑
+- **环境 ABI**：非配平 torch/TE → backward SIGSEGV。务必用镜像。
+- **9B 是 hybrid**（线性注意力+MTP）：转换/训练用 `qwen3.5-9B.sh` 的 spec（脚本已 source）；先 mock 冒烟。
+- **显存**：9B+TP=2+sglang 于 4×80G；OOM 就升 TP 或降 `max_tokens_per_gpu`（recompute-full 已开）。
+- **docking 吞吐**：同步、`vina_max_workers=1` 会堵 rollout；`config_real.json` 里调大 workers + 开缓存。

--- a/rl/slime_launch/HANDOFF.md
+++ b/rl/slime_launch/HANDOFF.md
@@ -115,5 +115,5 @@ srun bash $LDM/rl/slime_launch/run_train_real_9b.sh
 - **TE / backward**:aarch64 上 TE 是 ABI 最敏感的一环;装完先按 §6 P0 用 1.5B 冒烟确认 backward 不 SIGSEGV,再上 9B。
 - **9B 是 hybrid**(线性注意力+MTP):转换/训练用 `qwen3.5-9B.sh` 的 spec(脚本已 source);先用 real 极小 count 冒烟。
 - **显存**:9B + TP2/4 + sglang 于 96GB/卡,宽裕;OOM 就升 TP 或降 `max_tokens_per_gpu`(recompute-full 已开)。
-- **docking 吞吐**:同步、`vina_max_workers=1` 会堵 rollout;`config_real.json` 里调大 workers + 开缓存。
+- **docking 吞吐**:`config_real.json` 已把 `vina_max_workers=32`(vina 纯 CPU;GH200 每节点 288 ARM 核,可并行大批 docking,按核数继续调大);配合 canonical-SMILES 缓存进一步降开销。vina 二进制记得用 **aarch64** 版(§2B)。
 - **代码架构无关**:`ldm_rl` + reward 是纯 Python,已验证(zsgpu 上 53 测试通过);移植只在底层运行时。

--- a/rl/slime_launch/HANDOFF.md
+++ b/rl/slime_launch/HANDOFF.md
@@ -1,156 +1,119 @@
-# 小分子 RL 交接指南（装环境 · 跑 · 训练计划）
+# 小分子 RL 交接指南（装什么 · 怎么跑 · 训练计划）
 
-从零把 **小分子 acquisition-RL（GRPO on Slime）** 跑起来。运行矩阵见同目录 `RUNS.md`。
-**方向：train KRAS G12D → eval G12C & G12D**（G12D 评测器现成；G12C 只在离线评测时用）。
+从零把 **小分子 acquisition-RL（GRPO on Slime）** 跑起来。运行矩阵见 `RUNS.md`,实验设计见 `TRAINING_PLAN.md`。
+**方向：train KRAS G12D → eval G12C & G12D**（G12D 评测器现成;G12C 只在离线评测用,不进训练循环）。
+
+目标机器:**NVIDIA GH200(aarch64/ARM）Slurm 集群**(驱动 565 / CUDA 12.7,分区 `workq`,单节点 4×GH200 每卡 96GB)。
 
 ---
 
-## A. 装环境（最关键，别跳）
+## 0. 硬件前置
+- `uname -m` → **aarch64**;`nvidia-smi` → 驱动 **565 / CUDA 12.7**,GPU 96GB。
+- 1.5B 冒烟 1–2 卡够;9B 训练一节点 4 卡(TP2/TP4)。
+- 磁盘 ~150G(模型 + Megatron torch_dist + 中间产物)。
+- 能联网到 HuggingFace(下模型)、RCSB(受体,可选)。
 
-> ⚠️ 必须是**配平的 torch + 匹配 TE** 栈，否则 GRPO backward 会 SIGSEGV。
->
-> **先看你的机器架构(`uname -m`)：**
-> - **x86_64** → 用我们的 Docker 镜像(本节 A2),最省事。
-> - **aarch64 / ARM(如 GH200 集群)** → Docker 镜像(x86)**用不了**,走 **§G 的 ARM 移植**。
+## 1. ⚠️ CUDA 红线（最重要,先记住）
+驱动 565 = CUDA 12.7 → **所有 torch/CUDA 轮子必须是 `+cu128` 或 `+cu129`**。
+**`+cu130` 装上去 `torch.cuda.is_available()` 直接 False**(PyPI 默认 torch 已切 CUDA 13,装前先看 `+cuXXX` 后缀)。
 
-### A1. 代码
+## 2. 装环境（建一个 conda/venv,装两组依赖）
+
+```bash
+conda create -n ldm-rl python=3.11 -y && conda activate ldm-rl
+```
+
+### 2A. 训练栈（Slime RL）
+```bash
+# torch(aarch64, cu128) —— 别用 cu130
+pip install torch --index-url https://download.pytorch.org/whl/cu128
+python -c "import torch;print(torch.__version__, torch.cuda.is_available())"   # 必须 True
+
+# Transformer Engine(ABI 最敏感的一环;源码装,需 CUDA toolkit 头文件)
+pip install transformer_engine[pytorch]           # 装完必须能 import,且训练 backward 不 SIGSEGV(见 §6 P0 先验)
+
+# Megatron-LM: checkout slime 期望的 commit,放 PYTHONPATH
+git submodule update --init rl/slime rl/megatron-lm
+(cd rl/megatron-lm && git checkout 1dcf0dafa884ad52ffb243625717a3471643e087)
+
+# Slime(RL 编排)+ 依赖
+pip install -e rl/slime --no-deps
+pip install ray                                    # slime 用 ray 起 actor/rollout
+
+# sglang(rollout 推理引擎;装 aarch64 可用版本)
+pip install "sglang[all]"
+
+# APEX(可选;脚本用 --no-gradient-accumulation-fusion 时可不装)
+```
+> 若 TE / sglang 在 ARM 上源码装困难:可用 **NGC 的 aarch64 PyTorch 容器**(apptainer)当底座,里面 torch+TE 已配平——但你要求纯装环境,这里给 pip 路径,TE 那步失败就退容器。
+
+### 2B. 小分子评测栈（docking + GP + activity，real reward 必需）
+来自 `tasks/small_molecule/pyproject.toml`:
+```bash
+pip install gpytorch gauche lightgbm scikit-learn joblib \
+            rdkit meeko gemmi numpy scipy pandas omegaconf pydantic python-dotenv pyyaml openai
+# vina 二进制(aarch64):
+conda install -c conda-forge vina        # 或源码编 AutoDock Vina;记住它的路径,填进 config_real.json 的 vina_bin
+```
+
+### 2C. LDM 仓库本体
 ```bash
 git clone --recurse-submodules -b rl https://github.com/YihangChen9/Large-Discovery-Models.git LDM
 cd LDM
-git submodule update --init rl/slime rl/megatron-lm
-cd rl/megatron-lm && git checkout 1dcf0dafa884ad52ffb243625717a3471643e087 && cd ../..
+export PYTHONPATH=$PWD/rl/megatron-lm:$PWD/rl:$PWD:$PYTHONPATH
 ```
 
-### A2. 环境镜像（三选一，优先第 1）
-> `image.yangtzeailab.com` 是**私有 Harbor**(不能匿名 pull),需先登录。
-1. **拿到 Harbor 凭据(推荐:pull-only robot token)** → 登录后拉：
-   ```bash
-   docker login image.yangtzeailab.com -u <robot名> -p <robot-token>
-   docker pull image.yangtzeailab.com/opensandbox/ldm-slime-rl:latest
-   ```
-2. **没凭据但拿到镜像 tar** → 导入(有权限方 `docker save ... | gzip` 导出,约十几~几十 G)：
-   `gunzip -c ldm-slime-rl.tar.gz | docker load`
-3. **都不行** → 用 `rl/slime/build_conda.sh` 重建（torch 2.11 + TE 2.16.1 + 匹配 megatron/sglang commit），再按 `rl/SLIME_TRAINING.md` 打 6 个 patch。**最容易踩坑，尽量避免。**
-
-镜像里已备：conda env `/root/micromamba/envs/slime`、Megatron `/root/megatron-lm`、torch 2.11+cu129、匹配 TE、rdkit/meeko（docking 用）。
-
-### A3. 起容器（挂代码 + 资产盘 + GPU）
-```bash
-docker run --gpus all -it --shm-size=32g \
-  -v /path/to/LDM:/mnt/data0/ys/LDM \
-  -v /path/to/assets:/mnt/data0 \
-  image.yangtzeailab.com/opensandbox/ldm-slime-rl:latest bash
-```
-> 脚本里的路径都写死在 `/mnt/data0/...`，把资产放到对应位置最省事（见 B）。
-
----
-
-## B. 资产（放到这些路径）
+## 3. 资产（放到脚本里写死的路径,或改脚本）
 
 | 资产 | 路径 | 来源 |
 |---|---|---|
-| base 模型 Qwen3.5-9B | `/mnt/data0/hf_models/models/Qwen3.5-9B` | HF `Qwen/Qwen3.5-9B` |
-| SFT no-GP 模型 | `/mnt/data0/hf_models/models/LDM-CoT-SFT` | HF `Yangtze-ailab/LDM-CoT-SFT-Qwen3.5-9B-MixedScience` |
-| 冒烟 Qwen2.5-1.5B | `/mnt/data0/hf_models/models/Qwen2.5-1.5B-Instruct` | HF |
-| vina 二进制 | `/mnt/data0/dock-project/bin/vina` | 随 assets 包 |
+| base Qwen3.5-9B | `.../hf_models/models/Qwen3.5-9B` | HF `Qwen/Qwen3.5-9B` |
+| SFT no-GP 模型 | `.../hf_models/models/LDM-CoT-SFT` | HF `Yangtze-ailab/LDM-CoT-SFT-Qwen3.5-9B-MixedScience` |
+| 冒烟 Qwen2.5-1.5B | `.../hf_models/models/Qwen2.5-1.5B-Instruct` | HF |
+| vina 二进制(aarch64) | 见 §2B,填进 `config_real.json:vina_bin` | conda-forge / 源码 |
 | G12D 活性模型 | `tasks/small_molecule/resources/models/best_g12d_model.joblib` | **已在 repo** |
-| 8UN5 受体（制备好） | `/mnt/data0/ys/LDM/docking_work/receptors/…` | 随 assets 包 / 或 meeko 从 RCSB 8UN5 重制备 |
+| 8UN5 受体 | `docking_work/receptors/…` | 随包 / meeko 从 RCSB 8UN5 制备 |
 
-下模型：
 ```bash
 pip install -U "huggingface_hub[cli]"
-hf download Qwen/Qwen3.5-9B --local-dir /mnt/data0/hf_models/models/Qwen3.5-9B
-hf download Yangtze-ailab/LDM-CoT-SFT-Qwen3.5-9B-MixedScience --local-dir /mnt/data0/hf_models/models/LDM-CoT-SFT
+hf download Qwen/Qwen3.5-9B --local-dir .../hf_models/models/Qwen3.5-9B
+hf download Yangtze-ailab/LDM-CoT-SFT-Qwen3.5-9B-MixedScience --local-dir .../hf_models/models/LDM-CoT-SFT
 ```
 
----
-
-## C. 准备（一次）
+## 4. 准备（一次）
 ```bash
-cd /mnt/data0/ys/LDM/rl/slime_launch
-# 1) 转 Megatron torch_dist（base + SFT 各一次）
-MODEL_HF=/mnt/data0/hf_models/models/Qwen3.5-9B  SAVE=/mnt/data0/ys/LDM/rl/qwen3.5-9B_torch_dist      bash convert_9b.sh
-MODEL_HF=/mnt/data0/hf_models/models/LDM-CoT-SFT SAVE=/mnt/data0/ys/LDM/rl/qwen3.5-9B-sft_torch_dist  bash convert_9b.sh
-# 2) 生成 4 个 run 的 episodes（reward 已烤进数据）
+cd rl/slime_launch
+# 转 Megatron torch_dist(base + SFT 各一次)
+MODEL_HF=.../Qwen3.5-9B  SAVE=.../rl/qwen3.5-9B_torch_dist      bash convert_9b.sh
+MODEL_HF=.../LDM-CoT-SFT SAVE=.../rl/qwen3.5-9B-sft_torch_dist  bash convert_9b.sh
+# 生成 4 个 run 的 episodes(reward 已烤进数据)
 bash gen_episodes_runs.sh
-# 3) 暖共享 GP（rollout-only，dock warmup.num_samples 个分子）
+# 暖共享 GP(rollout-only,dock warmup.num_samples 个分子)
 bash run_warmup_real_slime.sh
 ```
 
----
-
-## D. 怎么跑（4 个 run，各 4 卡 / TP=2）
-命令全在 **`RUNS.md`**（R1 base·acq-max / R2 SFT·acq-max / R3 SFT·真reward / R4 SFT·acq-mean）。每个 run 建议 **≥3–5 seed** 出误差棒。开 wandb 加 `export WANDB_KEY=<key>`。
-
----
-
-## E. 训练计划（分阶段，带验证闸）
-
-**P0 — 环境 & backward 验证（1.5B，最便宜，先做这个）**
-用现成 `qwen2.5-1.5B_torch_dist_te` 跑 `run_train_real_shared.sh`（3 卡）。
-✅ 通过标准：GRPO **backward 不 SIGSEGV**、reward/loss 有正常值、走过 ≥5 rollout step、能 `--save`。这一步同时验证 docking + acquisition reward + bridge 全链路。
-
-**P1 — 9B 冒烟（mock，验 hybrid）**
-转好 9B torch_dist 后，把 episodes 改 `--mode mock` 跑 `run_train_real_9b.sh`。
-✅ 通过标准：9B hybrid **backward 能过**、不 OOM、reward 会动。专治"Qwen3.5 hybrid 未验证"。
-
-**P2 — 真训练（4 个 run × seed，real）**
-按 `RUNS.md` 起 R1–R4，全部 **train G12D**。
-- R1 vs R2：base-RL vs SFT-RL（SFT 打底有没有用）
-- R2 vs R3 vs R4：reward 消融（acq-max / 真结果 / acq-mean）
-
-**评测（train D → 测 C & D）**
-取各 run 的 best checkpoint，用离线 eval harness 在 **G12C 和 G12D** 上跑 LDM loop（budget 80，5 seed），比 hypervolume。参照行：base（无RL）、SFT（无RL）。
-> G12C 评测器 = 原 G12C campaign 的 G12C 受体 + G12C 活性模型（论文 G12C 那列跑的那套）。
-
----
-
-## F. 已知坑
-- **环境 ABI**：非配平 torch/TE → backward SIGSEGV。务必用镜像。
-- **9B 是 hybrid**（线性注意力+MTP）：转换/训练用 `qwen3.5-9B.sh` 的 spec（脚本已 source）；先 mock 冒烟。
-- **显存**：9B+TP=2+sglang 于 4×80G；OOM 就升 TP 或降 `max_tokens_per_gpu`（recompute-full 已开）。
-- **docking 吞吐**：同步、`vina_max_workers=1` 会堵 rollout；`config_real.json` 里调大 workers + 开缓存。
-
----
-
-## G. 在 GH200 (aarch64) 集群上跑 —— ARM 移植
-
-目标集群是 **NVIDIA GH200 Grace Hopper（aarch64/ARM）**，Slurm 调度。硬件很强、且没有 delta 那种"实例几分钟就被回收"的问题，**适合长时训练**；代价是**整套 x86 运行时都得换成 aarch64**。
-
-### G1. 集群速览
-| 项 | 值 |
-|---|---|
-| 规模 | 1,320 节点 / 5,280× GH200 |
-| 单节点 | 4× GH200（每个 = Grace CPU + Hopper H100，**GPU 96GB**），节点内 NVLink |
-| 调度 | Slurm，分区 `workq`，`MaxTime=UNLIMITED`（默认 4h，可申请更长） |
-| 驱动 / CUDA | **565.57.01 / CUDA 12.7**，compute capability 9.0 |
-| 已有环境 | `~/envs/ldm-venv`（LDM 共享层）、`~/envs/ldm-nanogpt`（torch 2.9.1+cu128） |
-
-### G2. 为什么不能直接用本仓库的 x86 资产
-- **`ldm-slime-rl` Docker 镜像是 x86** → GH200 跑不了(先 `docker manifest inspect` 确认它不是 multi-arch;基本是单 x86)。
-- **`vina` 二进制是 x86 ELF** → 要重编 **aarch64 版**(AutoDock Vina 支持 ARM 源码编译,或用 conda-forge 的 aarch64 包)。
-- **blessed torch 2.11 + TE 2.16.1 是 x86** → 换 **aarch64 + CUDA 12.7** 版,ABI 配平要在 ARM 上重做一遍。
-
-### G3. ⚠️ CUDA 版本红线
-驱动 565 = CUDA 12.7：**torch 轮子必须是 `+cu128` 或 `+cu129`**；**`+cu130` 装上去 `torch.cuda.is_available()` 直接 False**（PyPI 默认 torch 已切 CUDA 13，装前先看 `+cuXXX` 后缀）。
-
-### G4. 推荐移植路径
-**用 NVIDIA NGC 的 aarch64 PyTorch 容器当底座**（apptainer/enroot/pyxis 拉），它就是给 GH200 编的、torch+TE 已配平，直接躲开 ABI 地狱：
-1. 拉 NGC PyTorch(aarch64，CUDA≤12.7 对应 tag)容器。
-2. 在里面装 **slime + megatron-lm(checkout `1dcf0dafa…`) + sglang**(RL 特有、ARM 上要重装验证的部分)。
-3. **验 GRPO backward**（ARM 上重新确认不 SIGSEGV）——先用 1.5B mock 冒烟(HANDOFF §E P0/P1)。
-4. 编/装 **aarch64 vina**，`config_real.json` 的 `vina_bin` 指向它。
-5. 模型/数据同 §B–§C（模型从 HF 下,与架构无关）。
-
-### G5. Slurm 提交（示例）
-把 `run_train_real_9b.sh` 包进 sbatch;一个节点 4× GH200 → **TP 最多 4**(注意脚本里 `CUDA_VISIBLE_DEVICES` / `--rollout-num-gpus` / `--actor-num-gpus-per-node` 按 4 卡调):
+## 5. 怎么跑（4 个 run;命令全在 `RUNS.md`）
+一节点 4×GH200 → TP2/TP4。**注意脚本里的 `CUDA_VISIBLE_DEVICES` / `--rollout-num-gpus` / `--actor-num-gpus-per-node` 按节点 4 卡调**。Slurm 提交:
 ```bash
 #!/bin/bash
 #SBATCH -p workq -N 1 --gres=gpu:4 -t 24:00:00 -J ldm-rl-R2
-srun apptainer exec --nv ngc-pytorch-aarch64.sif \
-     bash /path/to/LDM/rl/slime_launch/run_train_real_9b.sh
+conda activate ldm-rl
+export PYTHONPATH=$LDM/rl/megatron-lm:$LDM/rl:$LDM
+srun bash $LDM/rl/slime_launch/run_train_real_9b.sh
 ```
-> GH200 每卡 96GB,9B + TP2/TP4 显存宽裕(参考:GLM-5.3 FP8 TP4 单节点已验证,每卡 ~77GB)。
+每个 run 建议 ≥3–5 seed(`--seed-offset`)。开 wandb: `export WANDB_KEY=<key>`。
 
-### G6. 一句话
-集群本身很适合(稳、无限时长、海量 GH200);**唯一的活是 aarch64 移植**——主要就是"在 NGC aarch64 容器里把 slime/megatron/sglang/TE 跑通 + 编个 aarch64 vina"。代码(`ldm_rl` + reward)是架构无关的 Python,不用改。
+## 6. 训练计划（分阶段,带验证闸;实验组见 TRAINING_PLAN.md）
+1. **P0**:1.5B 跑通 GRPO,验 **backward(ARM/TE 是否 SIGSEGV)+ docking + reward** 全链路。**这是最先做的闸——TE 装对没对,这一步见分晓。**
+2. **P1**:9B **real 极小 count**(如 count=1、iterations=2,只 dock 极少分子)冒烟,验 hybrid backward / 显存。**训练全程 real,不用 mock。**
+3. **P2**:R1–R4 × seed 真训练(train G12D)。
+4. **评测**:离线在 C & D 上评,填 TRAINING_PLAN 里的对照表。
+   - 前置(可并行):`tasks/small_molecule/core/activity_modeling/train_g12c_qsar.py` + `g12c_docking_benchmark.csv` 训出 `best_g12c_model.joblib`(受体沿用 8UN5)。
+
+## 7. 已知坑
+- **CUDA 红线**:torch 只用 `+cu128/+cu129`,cu130 → `cuda.is_available()=False`(§1)。
+- **TE / backward**:aarch64 上 TE 是 ABI 最敏感的一环;装完先按 §6 P0 用 1.5B 冒烟确认 backward 不 SIGSEGV,再上 9B。
+- **9B 是 hybrid**(线性注意力+MTP):转换/训练用 `qwen3.5-9B.sh` 的 spec(脚本已 source);先用 real 极小 count 冒烟。
+- **显存**:9B + TP2/4 + sglang 于 96GB/卡,宽裕;OOM 就升 TP 或降 `max_tokens_per_gpu`(recompute-full 已开)。
+- **docking 吞吐**:同步、`vina_max_workers=1` 会堵 rollout;`config_real.json` 里调大 workers + 开缓存。
+- **代码架构无关**:`ldm_rl` + reward 是纯 Python,已验证(zsgpu 上 53 测试通过);移植只在底层运行时。

--- a/rl/slime_launch/HANDOFF.md
+++ b/rl/slime_launch/HANDOFF.md
@@ -18,11 +18,14 @@ cd rl/megatron-lm && git checkout 1dcf0dafa884ad52ffb243625717a3471643e087 && cd
 ```
 
 ### A2. 环境镜像（三选一，优先第 1）
-1. **能访问镜像仓库** → 直接拉：
+> `image.yangtzeailab.com` 是**私有 Harbor**(不能匿名 pull),需先登录。
+1. **拿到 Harbor 凭据(推荐:pull-only robot token)** → 登录后拉：
    ```bash
+   docker login image.yangtzeailab.com -u <robot名> -p <robot-token>
    docker pull image.yangtzeailab.com/opensandbox/ldm-slime-rl:latest
    ```
-2. **拿到镜像 tar** → 导入：`gunzip -c ldm-slime-rl.tar.gz | docker load`
+2. **没凭据但拿到镜像 tar** → 导入(有权限方 `docker save ... | gzip` 导出,约十几~几十 G)：
+   `gunzip -c ldm-slime-rl.tar.gz | docker load`
 3. **都不行** → 用 `rl/slime/build_conda.sh` 重建（torch 2.11 + TE 2.16.1 + 匹配 megatron/sglang commit），再按 `rl/SLIME_TRAINING.md` 打 6 个 patch。**最容易踩坑，尽量避免。**
 
 镜像里已备：conda env `/root/micromamba/envs/slime`、Megatron `/root/megatron-lm`、torch 2.11+cu129、匹配 TE、rdkit/meeko（docking 用）。

--- a/rl/slime_launch/HANDOFF.md
+++ b/rl/slime_launch/HANDOFF.md
@@ -7,7 +7,11 @@
 
 ## A. 装环境（最关键，别跳）
 
-> ⚠️ 必须是**配平的 torch 2.11 + 匹配 TE** 栈，否则 GRPO backward 会 SIGSEGV。**强烈建议直接用我们的 Docker 镜像**，不要自己从头 pip 装。
+> ⚠️ 必须是**配平的 torch + 匹配 TE** 栈，否则 GRPO backward 会 SIGSEGV。
+>
+> **先看你的机器架构(`uname -m`)：**
+> - **x86_64** → 用我们的 Docker 镜像(本节 A2),最省事。
+> - **aarch64 / ARM(如 GH200 集群)** → Docker 镜像(x86)**用不了**,走 **§G 的 ARM 移植**。
 
 ### A1. 代码
 ```bash
@@ -106,3 +110,47 @@ bash run_warmup_real_slime.sh
 - **9B 是 hybrid**（线性注意力+MTP）：转换/训练用 `qwen3.5-9B.sh` 的 spec（脚本已 source）；先 mock 冒烟。
 - **显存**：9B+TP=2+sglang 于 4×80G；OOM 就升 TP 或降 `max_tokens_per_gpu`（recompute-full 已开）。
 - **docking 吞吐**：同步、`vina_max_workers=1` 会堵 rollout；`config_real.json` 里调大 workers + 开缓存。
+
+---
+
+## G. 在 GH200 (aarch64) 集群上跑 —— ARM 移植
+
+目标集群是 **NVIDIA GH200 Grace Hopper（aarch64/ARM）**，Slurm 调度。硬件很强、且没有 delta 那种"实例几分钟就被回收"的问题，**适合长时训练**；代价是**整套 x86 运行时都得换成 aarch64**。
+
+### G1. 集群速览
+| 项 | 值 |
+|---|---|
+| 规模 | 1,320 节点 / 5,280× GH200 |
+| 单节点 | 4× GH200（每个 = Grace CPU + Hopper H100，**GPU 96GB**），节点内 NVLink |
+| 调度 | Slurm，分区 `workq`，`MaxTime=UNLIMITED`（默认 4h，可申请更长） |
+| 驱动 / CUDA | **565.57.01 / CUDA 12.7**，compute capability 9.0 |
+| 已有环境 | `~/envs/ldm-venv`（LDM 共享层）、`~/envs/ldm-nanogpt`（torch 2.9.1+cu128） |
+
+### G2. 为什么不能直接用本仓库的 x86 资产
+- **`ldm-slime-rl` Docker 镜像是 x86** → GH200 跑不了(先 `docker manifest inspect` 确认它不是 multi-arch;基本是单 x86)。
+- **`vina` 二进制是 x86 ELF** → 要重编 **aarch64 版**(AutoDock Vina 支持 ARM 源码编译,或用 conda-forge 的 aarch64 包)。
+- **blessed torch 2.11 + TE 2.16.1 是 x86** → 换 **aarch64 + CUDA 12.7** 版,ABI 配平要在 ARM 上重做一遍。
+
+### G3. ⚠️ CUDA 版本红线
+驱动 565 = CUDA 12.7：**torch 轮子必须是 `+cu128` 或 `+cu129`**；**`+cu130` 装上去 `torch.cuda.is_available()` 直接 False**（PyPI 默认 torch 已切 CUDA 13，装前先看 `+cuXXX` 后缀）。
+
+### G4. 推荐移植路径
+**用 NVIDIA NGC 的 aarch64 PyTorch 容器当底座**（apptainer/enroot/pyxis 拉），它就是给 GH200 编的、torch+TE 已配平，直接躲开 ABI 地狱：
+1. 拉 NGC PyTorch(aarch64，CUDA≤12.7 对应 tag)容器。
+2. 在里面装 **slime + megatron-lm(checkout `1dcf0dafa…`) + sglang**(RL 特有、ARM 上要重装验证的部分)。
+3. **验 GRPO backward**（ARM 上重新确认不 SIGSEGV）——先用 1.5B mock 冒烟(HANDOFF §E P0/P1)。
+4. 编/装 **aarch64 vina**，`config_real.json` 的 `vina_bin` 指向它。
+5. 模型/数据同 §B–§C（模型从 HF 下,与架构无关）。
+
+### G5. Slurm 提交（示例）
+把 `run_train_real_9b.sh` 包进 sbatch;一个节点 4× GH200 → **TP 最多 4**(注意脚本里 `CUDA_VISIBLE_DEVICES` / `--rollout-num-gpus` / `--actor-num-gpus-per-node` 按 4 卡调):
+```bash
+#!/bin/bash
+#SBATCH -p workq -N 1 --gres=gpu:4 -t 24:00:00 -J ldm-rl-R2
+srun apptainer exec --nv ngc-pytorch-aarch64.sif \
+     bash /path/to/LDM/rl/slime_launch/run_train_real_9b.sh
+```
+> GH200 每卡 96GB,9B + TP2/TP4 显存宽裕(参考:GLM-5.3 FP8 TP4 单节点已验证,每卡 ~77GB)。
+
+### G6. 一句话
+集群本身很适合(稳、无限时长、海量 GH200);**唯一的活是 aarch64 移植**——主要就是"在 NGC aarch64 容器里把 slime/megatron/sglang/TE 跑通 + 编个 aarch64 vina"。代码(`ldm_rl` + reward)是架构无关的 Python,不用改。

--- a/rl/slime_launch/RUNS.md
+++ b/rl/slime_launch/RUNS.md
@@ -2,19 +2,25 @@
 
 Real-mode GRPO on the small-molecule LDM loop. **Train on KRAS G12D** (ready
 evaluator: `best_g12d_model.joblib` + 8UN5), **evaluate on G12C and G12D**.
-Reward = acquisition (default), aggregated per-round. Two axes, sharing R2 as
-the pivot:
+**One episode file per run** — each run gets its **own** `gp_history_file` +
+`output_dir` (sharing a GP across runs couples their rewards; see PR #2 / nb 06).
+`config_real.json` default reward is now **hypervolume (ΔHV)**; the acquisition
+variants are kept as an ablation. Two axes, sharing R2 as the pivot:
 
 | Run | Model (`MODEL_HF`) | Reward | Episodes file |
 |-----|--------------------|--------|---------------|
-| **R1** | Qwen3.5-9B base | acquisition-**max** | `rl_episodes_sm_acqmax.jsonl` |
-| **R2** | SFT (no-GP) | acquisition-**max** | `rl_episodes_sm_acqmax.jsonl` |
-| **R3** | SFT (no-GP) | **hypervolume** (ΔHV, real outcome) | `rl_episodes_sm_hv.jsonl` |
-| **R4** | SFT (no-GP) | acquisition-**mean** | `rl_episodes_sm_acqmean.jsonl` |
+| **R1** | Qwen3.5-9B base | acquisition-**max** | `rl_episodes_sm_R1.jsonl` |
+| **R2** | SFT (no-GP) | acquisition-**max** | `rl_episodes_sm_R2.jsonl` |
+| **R3** | SFT (no-GP) | **hypervolume** (ΔHV, real outcome) | `rl_episodes_sm_R3.jsonl` |
+| **R4** | SFT (no-GP) | acquisition-**mean** | `rl_episodes_sm_R4.jsonl` |
 
 - R1 vs R2 isolates the **model** (base vs SFT-init).
 - R2 vs R3 vs R4 isolates the **reward** (decision-time max / real outcome / decision-time mean).
-- Run each with ≥3–5 seeds (`--seed-offset`) for error bars.
+- Seeds: change the **environment** seed by regenerating with
+  `python -m ldm_rl.episodes --seed-offset N` (it is an `episodes.py` flag, not a
+  slime one); ≥3–5 seeds per run for error bars.
+- With acquisition, watch `zero_std/count_0.0`: if GRPO groups collapse to equal
+  rewards (EHVI decay / collisions), the gradient is zero — prefer ΔHV (R3).
 
 ## 0. One-time prep
 ```bash
@@ -22,10 +28,13 @@ cd /mnt/data0/ys/LDM/rl/slime_launch
 # convert both models HF -> Megatron torch_dist
 MODEL_HF=/mnt/data0/hf_models/models/Qwen3.5-9B                 SAVE=/mnt/data0/ys/LDM/rl/qwen3.5-9B_torch_dist      bash convert_9b.sh
 MODEL_HF=/mnt/data0/hf_models/models/LDM-CoT-SFT               SAVE=/mnt/data0/ys/LDM/rl/qwen3.5-9B-sft_torch_dist  bash convert_9b.sh
-# generate all episode files (reward baked in)
+# generate one episode file per run (R1-R4), each with its own GP + output dir
 bash gen_episodes_runs.sh
-# warm the shared GP once (rollout-only, docks warmup.num_samples molecules)
-bash run_warmup_real_slime.sh    # or the 9B warmup once wired; GP history is model-agnostic
+# warm the BASE GP once (rollout-only, docks warmup.num_samples molecules)
+bash run_warmup_real_slime.sh    # GP history is model-agnostic
+# seed each run's GP from the warm base (so runs are isolated but warm-started)
+BASE_GP=/mnt/data0/ys/LDM/rl/sm_rl_gp_history.jsonl
+for r in R1 R2 R3 R4; do cp "$BASE_GP" /mnt/data0/ys/LDM/rl/gp_history/$r.jsonl; done
 ```
 
 ## 1. Launch runs (4 GPUs each, TP=2)
@@ -35,13 +44,13 @@ SFT=/mnt/data0/hf_models/models/LDM-CoT-SFT ;      SFT_REF=/mnt/data0/ys/LDM/rl/
 R=/mnt/data0/ys/LDM/rl ; export WANDB_KEY=<your-wandb-key>   # optional
 
 # R1 base, acq-max
-MODEL_HF=$BASE MODEL_REF=$BASE_REF EPISODES=$R/../rl_episodes_sm_acqmax.jsonl  SAVE=$R/qwen3.5-9B_rl_R1_base_acqmax  WANDB_RUN=R1_base_acqmax  bash run_train_real_9b.sh
+MODEL_HF=$BASE MODEL_REF=$BASE_REF EPISODES=$R/../rl_episodes_sm_R1.jsonl  SAVE=$R/qwen3.5-9B_rl_R1_base_acqmax  WANDB_RUN=R1_base_acqmax  bash run_train_real_9b.sh
 # R2 sft, acq-max
-MODEL_HF=$SFT  MODEL_REF=$SFT_REF  EPISODES=$R/../rl_episodes_sm_acqmax.jsonl  SAVE=$R/qwen3.5-9B_rl_R2_sft_acqmax   WANDB_RUN=R2_sft_acqmax   bash run_train_real_9b.sh
-# R3 sft, real reward
-MODEL_HF=$SFT  MODEL_REF=$SFT_REF  EPISODES=$R/../rl_episodes_sm_hv.jsonl      SAVE=$R/qwen3.5-9B_rl_R3_sft_hv       WANDB_RUN=R3_sft_hv       bash run_train_real_9b.sh
+MODEL_HF=$SFT  MODEL_REF=$SFT_REF  EPISODES=$R/../rl_episodes_sm_R2.jsonl  SAVE=$R/qwen3.5-9B_rl_R2_sft_acqmax   WANDB_RUN=R2_sft_acqmax   bash run_train_real_9b.sh
+# R3 sft, ΔHV (real outcome)
+MODEL_HF=$SFT  MODEL_REF=$SFT_REF  EPISODES=$R/../rl_episodes_sm_R3.jsonl  SAVE=$R/qwen3.5-9B_rl_R3_sft_hv       WANDB_RUN=R3_sft_hv       bash run_train_real_9b.sh
 # R4 sft, acq-mean
-MODEL_HF=$SFT  MODEL_REF=$SFT_REF  EPISODES=$R/../rl_episodes_sm_acqmean.jsonl SAVE=$R/qwen3.5-9B_rl_R4_sft_acqmean  WANDB_RUN=R4_sft_acqmean  bash run_train_real_9b.sh
+MODEL_HF=$SFT  MODEL_REF=$SFT_REF  EPISODES=$R/../rl_episodes_sm_R4.jsonl  SAVE=$R/qwen3.5-9B_rl_R4_sft_acqmean  WANDB_RUN=R4_sft_acqmean  bash run_train_real_9b.sh
 ```
 
 ## 2. Reward semantics

--- a/rl/slime_launch/RUNS.md
+++ b/rl/slime_launch/RUNS.md
@@ -1,0 +1,64 @@
+# Small-molecule RL — run matrix
+
+Real-mode GRPO on the small-molecule LDM loop. **Train on KRAS G12D** (ready
+evaluator: `best_g12d_model.joblib` + 8UN5), **evaluate on G12C and G12D**.
+Reward = acquisition (default), aggregated per-round. Two axes, sharing R2 as
+the pivot:
+
+| Run | Model (`MODEL_HF`) | Reward | Episodes file |
+|-----|--------------------|--------|---------------|
+| **R1** | Qwen3.5-9B base | acquisition-**max** | `rl_episodes_sm_acqmax.jsonl` |
+| **R2** | SFT (no-GP) | acquisition-**max** | `rl_episodes_sm_acqmax.jsonl` |
+| **R3** | SFT (no-GP) | **improvement** (real outcome) | `rl_episodes_sm_improve.jsonl` |
+| **R4** | SFT (no-GP) | acquisition-**mean** | `rl_episodes_sm_acqmean.jsonl` |
+
+- R1 vs R2 isolates the **model** (base vs SFT-init).
+- R2 vs R3 vs R4 isolates the **reward** (decision-time max / real outcome / decision-time mean).
+- Run each with ≥3–5 seeds (`--seed-offset`) for error bars.
+
+## 0. One-time prep
+```bash
+cd /mnt/data0/ys/LDM/rl/slime_launch
+# convert both models HF -> Megatron torch_dist
+MODEL_HF=/mnt/data0/hf_models/models/Qwen3.5-9B                 SAVE=/mnt/data0/ys/LDM/rl/qwen3.5-9B_torch_dist      bash convert_9b.sh
+MODEL_HF=/mnt/data0/hf_models/models/LDM-CoT-SFT               SAVE=/mnt/data0/ys/LDM/rl/qwen3.5-9B-sft_torch_dist  bash convert_9b.sh
+# generate all episode files (reward baked in)
+bash gen_episodes_runs.sh
+# warm the shared GP once (rollout-only, docks warmup.num_samples molecules)
+bash run_warmup_real_slime.sh    # or the 9B warmup once wired; GP history is model-agnostic
+```
+
+## 1. Launch runs (4 GPUs each, TP=2)
+```bash
+BASE=/mnt/data0/hf_models/models/Qwen3.5-9B ;      BASE_REF=/mnt/data0/ys/LDM/rl/qwen3.5-9B_torch_dist
+SFT=/mnt/data0/hf_models/models/LDM-CoT-SFT ;      SFT_REF=/mnt/data0/ys/LDM/rl/qwen3.5-9B-sft_torch_dist
+R=/mnt/data0/ys/LDM/rl ; export WANDB_KEY=<your-wandb-key>   # optional
+
+# R1 base, acq-max
+MODEL_HF=$BASE MODEL_REF=$BASE_REF EPISODES=$R/../rl_episodes_sm_acqmax.jsonl  SAVE=$R/qwen3.5-9B_rl_R1_base_acqmax  WANDB_RUN=R1_base_acqmax  bash run_train_real_9b.sh
+# R2 sft, acq-max
+MODEL_HF=$SFT  MODEL_REF=$SFT_REF  EPISODES=$R/../rl_episodes_sm_acqmax.jsonl  SAVE=$R/qwen3.5-9B_rl_R2_sft_acqmax   WANDB_RUN=R2_sft_acqmax   bash run_train_real_9b.sh
+# R3 sft, real reward
+MODEL_HF=$SFT  MODEL_REF=$SFT_REF  EPISODES=$R/../rl_episodes_sm_improve.jsonl SAVE=$R/qwen3.5-9B_rl_R3_sft_improve  WANDB_RUN=R3_sft_improve  bash run_train_real_9b.sh
+# R4 sft, acq-mean
+MODEL_HF=$SFT  MODEL_REF=$SFT_REF  EPISODES=$R/../rl_episodes_sm_acqmean.jsonl SAVE=$R/qwen3.5-9B_rl_R4_sft_acqmean  WANDB_RUN=R4_sft_acqmean  bash run_train_real_9b.sh
+```
+
+## 2. Reward semantics
+- `reward: acquisition`, `acquisition_agg: max|mean` — per-round reward is the
+  max (or mean) EHVI acquisition score of the evaluated candidate(s); episode
+  reward is the sum over rounds. (See `rl/ldm_rl/env.py::_acquisition_reward`.)
+- `reward: improvement` — per-round objective improvement over the incumbent
+  (real Vina + activity outcome), summed over rounds.
+
+## 3. Notes / risks
+- **Env**: use the `ldm-slime-rl` image (torch 2.11 + matched TE); other stacks
+  SIGSEGV on GRPO backward.
+- **First 9B run**: smoke with `--mode mock` (edit episodes to mock) to confirm
+  the hybrid backward + memory before spending real docking.
+- **Memory**: 9B + TP=2 + sglang on 4×80G. If OOM, raise TP or drop
+  `max_tokens_per_gpu`; recompute-full is already on.
+- **Docking throughput** is the real bottleneck for real reward; enable the
+  docking cache and raise `vina_max_workers` in `config_real.json` real_kwargs.
+- All 4 runs **train on G12D**; the G12C transfer number comes from the
+  offline eval harness, not from training.

--- a/rl/slime_launch/RUNS.md
+++ b/rl/slime_launch/RUNS.md
@@ -9,7 +9,7 @@ the pivot:
 |-----|--------------------|--------|---------------|
 | **R1** | Qwen3.5-9B base | acquisition-**max** | `rl_episodes_sm_acqmax.jsonl` |
 | **R2** | SFT (no-GP) | acquisition-**max** | `rl_episodes_sm_acqmax.jsonl` |
-| **R3** | SFT (no-GP) | **improvement** (real outcome) | `rl_episodes_sm_improve.jsonl` |
+| **R3** | SFT (no-GP) | **hypervolume** (ΔHV, real outcome) | `rl_episodes_sm_hv.jsonl` |
 | **R4** | SFT (no-GP) | acquisition-**mean** | `rl_episodes_sm_acqmean.jsonl` |
 
 - R1 vs R2 isolates the **model** (base vs SFT-init).
@@ -39,7 +39,7 @@ MODEL_HF=$BASE MODEL_REF=$BASE_REF EPISODES=$R/../rl_episodes_sm_acqmax.jsonl  S
 # R2 sft, acq-max
 MODEL_HF=$SFT  MODEL_REF=$SFT_REF  EPISODES=$R/../rl_episodes_sm_acqmax.jsonl  SAVE=$R/qwen3.5-9B_rl_R2_sft_acqmax   WANDB_RUN=R2_sft_acqmax   bash run_train_real_9b.sh
 # R3 sft, real reward
-MODEL_HF=$SFT  MODEL_REF=$SFT_REF  EPISODES=$R/../rl_episodes_sm_improve.jsonl SAVE=$R/qwen3.5-9B_rl_R3_sft_improve  WANDB_RUN=R3_sft_improve  bash run_train_real_9b.sh
+MODEL_HF=$SFT  MODEL_REF=$SFT_REF  EPISODES=$R/../rl_episodes_sm_hv.jsonl      SAVE=$R/qwen3.5-9B_rl_R3_sft_hv       WANDB_RUN=R3_sft_hv       bash run_train_real_9b.sh
 # R4 sft, acq-mean
 MODEL_HF=$SFT  MODEL_REF=$SFT_REF  EPISODES=$R/../rl_episodes_sm_acqmean.jsonl SAVE=$R/qwen3.5-9B_rl_R4_sft_acqmean  WANDB_RUN=R4_sft_acqmean  bash run_train_real_9b.sh
 ```
@@ -48,16 +48,20 @@ MODEL_HF=$SFT  MODEL_REF=$SFT_REF  EPISODES=$R/../rl_episodes_sm_acqmean.jsonl S
 - `reward: acquisition`, `acquisition_agg: max|mean` — per-round reward is the
   max (or mean) EHVI acquisition score of the evaluated candidate(s); episode
   reward is the sum over rounds. (See `rl/ldm_rl/env.py::_acquisition_reward`.)
-- `reward: improvement` — per-round objective improvement over the incumbent
-  (real Vina + activity outcome), summed over rounds.
+- `reward: hypervolume` — per-round **Pareto-front hypervolume improvement (ΔHV)**
+  from the real Vina + activity outcomes, summed over rounds (telescopes to the
+  campaign's total HV gain). `reward_ref_point` (oriented space) fixes the ref,
+  else a per-round nadir is used. `reward: improvement` (sum of per-objective
+  gains) also available but gameable across objectives.
 
 ## 3. Notes / risks
-- **Env**: use the `ldm-slime-rl` image (torch 2.11 + matched TE); other stacks
-  SIGSEGV on GRPO backward.
-- **First 9B run**: smoke with `--mode mock` (edit episodes to mock) to confirm
-  the hybrid backward + memory before spending real docking.
-- **Memory**: 9B + TP=2 + sglang on 4×80G. If OOM, raise TP or drop
-  `max_tokens_per_gpu`; recompute-full is already on.
+- **Env**: use a matched torch + TE stack (see HANDOFF §2); a mismatched stack
+  SIGSEGVs on GRPO backward.
+- **First 9B run**: smoke with a **tiny real** episode set (count=1, iterations=2)
+  to confirm the hybrid backward + memory before scaling up. Training is always
+  real — do not use mock.
+- **Memory**: 9B + TP=2/4 + sglang on 4 GPUs (96GB each on GH200). If OOM, raise
+  TP or drop `max_tokens_per_gpu`; recompute-full is already on.
 - **Docking throughput** is the real bottleneck for real reward; enable the
   docking cache and raise `vina_max_workers` in `config_real.json` real_kwargs.
 - All 4 runs **train on G12D**; the G12C transfer number comes from the

--- a/rl/slime_launch/TRAINING_PLAN.md
+++ b/rl/slime_launch/TRAINING_PLAN.md
@@ -1,0 +1,76 @@
+# 小分子 RL 训练计划（目标 · 模型 · 实验组）
+
+> 怎么装/怎么跑见 `HANDOFF.md` + `RUNS.md`。本文只讲**做什么、为什么**。
+
+## 1. 目标
+
+SFT 已经把"acquisition-tilted 搜索策略"的**格式与行为**蒸馏进 Qwen3.5-9B（见论文小分子结果）。
+本轮 RL 的目标是:**用真实评估反馈(GRPO),在 SFT 之上进一步强化这套搜索策略**,并回答三个问题:
+
+1. **RL 在 SFT 之上还有没有增益?**(SFT+RL vs SFT-only)
+2. **RL 需不需要 SFT 打底?**(SFT+RL vs base+RL)
+3. **哪种 reward 信号最有效?**(决策期 acquisition 的 max / mean vs 真实评估结果)
+
+**泛化设定:train KRAS G12D → 评测 G12C(迁移)+ G12D(同分布)。**
+> G12C/G12D 只差**活性模型**一个 joblib,**docking 受体 8UN5 两者共用**;所以 G12C 评测很轻,且**只在离线评测用,不进 RL 训练循环**(不阻塞训练)。
+
+## 2. 要训哪些模型（2 个起点 × RL）
+
+| 起点 | 说明 |
+|---|---|
+| **base Qwen3.5-9B** | 未微调,裸 base 起 RL(下界/对照) |
+| **SFT no-GP 模型** | `Yangtze-ailab/LDM-CoT-SFT-Qwen3.5-9B-MixedScience`,主力起点 |
+
+外加**无 RL 基线(不训,只评测)**:base(无RL)、SFT(无RL)——作为表格参照行。
+
+## 3. 做哪几组实验（4 个 RL run，两组消融，共用 R2 为枢轴）
+
+| Run | 起点 | reward | 归属 |
+|---|---|---|---|
+| **R1** | base | acquisition-max | Group A |
+| **R2** | SFT | acquisition-max | Group A + B（枢轴） |
+| **R3** | SFT | 真实评估结果(improvement / ΔHV) | Group B |
+| **R4** | SFT | acquisition-mean | Group B |
+
+- **Group A — 模型消融**:R1 vs R2 → "SFT 打底对 RL 有没有用"。
+- **Group B — reward 消融**:R2 vs R3 vs R4 → "决策期 acquisition(max/mean) vs 真实结果,哪个信号最好"。
+
+全部 **train G12D**;reward 已烤进各自 episodes(`gen_episodes_runs.sh`)。
+**每个 run 跑 ≥3–5 个 seed**(`--seed-offset`)出误差棒。
+
+## 4. 评测协议
+
+- 取每个 run 的 best checkpoint,放进小分子 LDM loop,在 **G12C 和 G12D 各跑 5 seed**,评测预算 budget=80。
+- 指标:**Pareto 前沿 hypervolume**(越高越好),对齐论文 `tab:smallmol-cot`。
+- 参照行:base(无RL)、SFT(无RL)、DeepSeek teacher(若要)。
+
+**最终对照表(每格 = C / D 的 HV):**
+
+| 策略 | G12C(迁移) | G12D(同分布) |
+|---|---|---|
+| base（无RL) | 参照 | 参照 |
+| SFT（无RL) | 参照 | 参照 |
+| R1 base+RL(acq-max) | | |
+| R2 SFT+RL(acq-max) | | |
+| R3 SFT+RL(真reward) | | |
+| R4 SFT+RL(acq-mean) | | |
+
+## 5. 预期结论 / 成功判据
+
+- **R2 > SFT(无RL)**:RL 在 SFT 之上有增益(核心卖点)。
+- **R2 > R1**:SFT 打底让 RL 更有效(而非从 base 硬学)。
+- **R3 vs R2 vs R4**:确定最佳 reward 信号;若 R3(真结果)≥ R2,说明该直接优化结果;若 acquisition 系列更稳,支持"蒸馏 acquisition"叙事。
+- **迁移(G12C)上仍有增益**:说明 RL 强化的是可迁移的搜索策略,不是对 G12D 的过拟合。
+
+## 6. 分阶段执行（带验证闸,细节见 HANDOFF §E）
+
+1. **P0**:1.5B 在真环境跑通 GRPO,验 **backward + docking + reward** 全链路。
+2. **P1**:9B **mock** 冒烟,验 hybrid backward / 显存。
+3. **P2**:R1–R4 × seed 真训练(train G12D)。
+4. **评测**:离线在 C & D 上评,填对照表。
+   - 前置(可并行):用 `train_g12c_qsar.py` + `g12c_docking_benchmark.csv` 训出 `best_g12c_model.joblib`(受体沿用 8UN5)。
+
+## 7. 规模 / 成本备注
+
+- 4 run × 5 seed = 20 次训练;每次 4×80G GPU、real docking 是主瓶颈(开缓存 + 并行 `vina_max_workers`)。
+- 若算力紧,先跑 **R2(主力)+ R1(对照)各 3 seed** 拿到核心结论,再补 R3/R4 与更多 seed。

--- a/rl/slime_launch/TRAINING_PLAN.md
+++ b/rl/slime_launch/TRAINING_PLAN.md
@@ -29,7 +29,7 @@ SFT 已经把"acquisition-tilted 搜索策略"的**格式与行为**蒸馏进 Qw
 |---|---|---|---|
 | **R1** | base | acquisition-max | Group A |
 | **R2** | SFT | acquisition-max | Group A + B（枢轴） |
-| **R3** | SFT | 真实评估结果(improvement / ΔHV) | Group B |
+| **R3** | SFT | 真实评估结果(**hypervolume ΔHV**) | Group B |
 | **R4** | SFT | acquisition-mean | Group B |
 
 - **Group A — 模型消融**:R1 vs R2 → "SFT 打底对 RL 有没有用"。
@@ -65,7 +65,7 @@ SFT 已经把"acquisition-tilted 搜索策略"的**格式与行为**蒸馏进 Qw
 ## 6. 分阶段执行（带验证闸,细节见 HANDOFF §E）
 
 1. **P0**:1.5B 在真环境跑通 GRPO,验 **backward + docking + reward** 全链路。
-2. **P1**:9B **mock** 冒烟,验 hybrid backward / 显存。
+2. **P1**:9B **real 极小 count**(count=1、iterations=2)冒烟,验 hybrid backward / 显存。**训练全程 real,不用 mock。**
 3. **P2**:R1–R4 × seed 真训练(train G12D)。
 4. **评测**:离线在 C & D 上评,填对照表。
    - 前置(可并行):用 `train_g12c_qsar.py` + `g12c_docking_benchmark.csv` 训出 `best_g12c_model.joblib`(受体沿用 8UN5)。

--- a/rl/slime_launch/config_real.json
+++ b/rl/slime_launch/config_real.json
@@ -12,7 +12,7 @@
     "iterations": 20,
     "reservoir_size": 2,
     "evaluations_per_round": 1,
-    "reward": "acquisition"
+    "reward": "hypervolume"
   },
   "training": {
     "num_rollout": 50,
@@ -31,7 +31,7 @@
     "vina_pdb_id": "8UN5",
     "vina_chain_id": "A",
     "method": "m1_stratified_direct_llm_sir",
-    "kernel": "sk",
+    "kernel": "fp",
     "acq": "ehvi",
     "acq_weights": "0.5,0.5",
     "gp_device": "cpu",

--- a/rl/slime_launch/config_real.json
+++ b/rl/slime_launch/config_real.json
@@ -37,7 +37,7 @@
     "gp_device": "cpu",
     "vina_exhaustiveness": 1,
     "vina_n_poses": 1,
-    "vina_max_workers": 1,
+    "vina_max_workers": 32,
     "output_dir": "/tmp/sm_rl_real_run"
   }
 }

--- a/rl/slime_launch/convert_9b.sh
+++ b/rl/slime_launch/convert_9b.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Convert a Qwen3.5-9B HF checkpoint -> Megatron torch_dist (ref-load format).
+# Usage:
+#   MODEL_HF=/mnt/data0/hf_models/models/Qwen3.5-9B \
+#   SAVE=/mnt/data0/ys/LDM/rl/qwen3.5-9B_torch_dist  bash convert_9b.sh
+set -ex
+REPO_ROOT=/mnt/data0/ys/LDM
+SLIME_ROOT=$REPO_ROOT/rl/slime
+MEGATRON_ROOT=/root/megatron-lm
+CONDA_PREFIX=/root/micromamba/envs/slime
+
+MODEL_HF=${MODEL_HF:-/mnt/data0/hf_models/models/Qwen3.5-9B}
+SAVE=${SAVE:-$REPO_ROOT/rl/qwen3.5-9B_torch_dist}
+
+export PATH=$CONDA_PREFIX/bin:$PATH
+export PYTHONPATH=$MEGATRON_ROOT:$REPO_ROOT/rl:$REPO_ROOT:$PYTHONPATH
+export CUDA_HOME=$CONDA_PREFIX
+export CUDA_VISIBLE_DEVICES=0
+
+cd "$SLIME_ROOT"
+source "$SLIME_ROOT/scripts/models/qwen3.5-9B.sh"   # sets MODEL_ARGS=(...)
+
+python tools/convert_hf_to_torch_dist.py \
+   ${MODEL_ARGS[@]} \
+   --hf-checkpoint "$MODEL_HF" \
+   --save "$SAVE"
+echo "converted -> $SAVE/"

--- a/rl/slime_launch/gen_episodes_runs.sh
+++ b/rl/slime_launch/gen_episodes_runs.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # Generate the episode prompt-data for every run in the matrix (see RUNS.md).
-# The reward policy + acquisition aggregation are baked into each jsonl here,
-# so the launcher only picks the model. Reads config_real.json for sizes and
-# the real-evaluation kwargs (vina/nn/target), and stamps gp_history_file into
-# each episode's real kwargs so the shared warm GP is wired automatically.
+# One file PER RUN (R1-R4), not per reward: R1 and R2 share a reward but are
+# different runs, so each must get its OWN gp_history_file + output_dir. Sharing
+# a GP or output dir across runs couples their rewards and breaks reproducibility
+# (see KangOxford PR #2 / notebook 06). The model is chosen at launch time, not here.
 set -eu
 REPO_ROOT=/mnt/data0/ys/LDM
 CONFIG=$REPO_ROOT/rl/slime_launch/config_real.json
@@ -13,25 +13,37 @@ EP=rl.ldm_rl.episodes
 read -r COUNT ITERS RES EVALS WARMUP WARMUP_ITERS < <(python3 -c "
 import json;c=json.load(open('$CONFIG'));e=c['episodes'];w=c['warmup']
 print(e['count'],e['iterations'],e['reservoir_size'],e['evaluations_per_round'],w['num_samples'],w['iterations'])")
+BASE_GP=$(python3 -c "import json;print(json.load(open('$CONFIG'))['gp_history_file'])")
 
-# real kwargs = config.real_kwargs + gp_history_file
-RK=$(python3 -c "
-import json;c=json.load(open('$CONFIG'))
-rk=dict(c['real_kwargs']);rk['gp_history_file']=c['gp_history_file']
-print(json.dumps(rk))")
+GP_DIR=$REPO_ROOT/rl/gp_history      # per-run GP files live here
+OUT_DIR=$REPO_ROOT/rl/run_out        # per-run docking output dirs live here
+mkdir -p "$GP_DIR" "$OUT_DIR"
 
-gen() {  # gen <out> <reward> <agg> <count> <iters>
-  python3 -m $EP --output "$REPO_ROOT/$1" --task small_molecule --mode real \
-    --count "$4" --iterations "$5" --reservoir-size "$RES" --evaluations-per-round "$EVALS" \
-    --reward "$2" --acquisition-agg "$3" --real-kwargs "$RK"
+# real_kwargs = config.real_kwargs but with a per-run gp_history_file + output_dir
+rk_json() {  # rk_json <gp_history_file> <output_dir>
+  python3 -c "
+import json,sys;c=json.load(open('$CONFIG'))
+rk=dict(c['real_kwargs']);rk['gp_history_file']=sys.argv[1];rk['output_dir']=sys.argv[2]
+print(json.dumps(rk))" "$1" "$2"
 }
 
-# warm-up (rollout-only; reward unused, keep acquisition for consistency)
-gen rl_episodes_sm_warmup.jsonl   acquisition  max  "$WARMUP" "$WARMUP_ITERS"
-# R1/R2: acquisition-max
-gen rl_episodes_sm_acqmax.jsonl   acquisition  max  "$COUNT"  "$ITERS"
-# R4: acquisition-mean
-gen rl_episodes_sm_acqmean.jsonl  acquisition  mean "$COUNT"  "$ITERS"
-# R3: real-outcome reward (Pareto hypervolume improvement over the observed front)
-gen rl_episodes_sm_hv.jsonl       hypervolume  max  "$COUNT"  "$ITERS"
-echo "episodes written to $REPO_ROOT/rl_episodes_sm_{warmup,acqmax,acqmean,hv}.jsonl"
+gen() {  # gen <out.jsonl> <reward> <agg> <count> <iters> <gp_history_file> <output_dir>
+  python3 -m $EP --output "$REPO_ROOT/$1" --task small_molecule --mode real \
+    --count "$4" --iterations "$5" --reservoir-size "$RES" --evaluations-per-round "$EVALS" \
+    --reward "$2" --acquisition-agg "$3" --real-kwargs "$(rk_json "$6" "$7")"
+}
+
+# warm-up (rollout-only) writes the shared BASE GP; each run is then seeded from it.
+gen rl_episodes_sm_warmup.jsonl acquisition max "$WARMUP" "$WARMUP_ITERS" "$BASE_GP" "$OUT_DIR/warmup"
+
+# One episode file PER RUN, each with its own GP + output dir.
+# R1 base / R2 SFT share the acquisition-max reward but stay isolated (own GP).
+gen rl_episodes_sm_R1.jsonl acquisition max  "$COUNT" "$ITERS" "$GP_DIR/R1.jsonl" "$OUT_DIR/R1"
+gen rl_episodes_sm_R2.jsonl acquisition max  "$COUNT" "$ITERS" "$GP_DIR/R2.jsonl" "$OUT_DIR/R2"
+gen rl_episodes_sm_R3.jsonl hypervolume max  "$COUNT" "$ITERS" "$GP_DIR/R3.jsonl" "$OUT_DIR/R3"
+gen rl_episodes_sm_R4.jsonl acquisition mean "$COUNT" "$ITERS" "$GP_DIR/R4.jsonl" "$OUT_DIR/R4"
+
+echo "episodes -> $REPO_ROOT/rl_episodes_sm_{warmup,R1,R2,R3,R4}.jsonl"
+echo "per-run GP under $GP_DIR/ , outputs under $OUT_DIR/"
+echo "BEFORE launching each run, seed its GP from the warm base:"
+echo "  for r in R1 R2 R3 R4; do cp \"$BASE_GP\" \"$GP_DIR/\$r.jsonl\"; done"

--- a/rl/slime_launch/gen_episodes_runs.sh
+++ b/rl/slime_launch/gen_episodes_runs.sh
@@ -32,6 +32,6 @@ gen rl_episodes_sm_warmup.jsonl   acquisition  max  "$WARMUP" "$WARMUP_ITERS"
 gen rl_episodes_sm_acqmax.jsonl   acquisition  max  "$COUNT"  "$ITERS"
 # R4: acquisition-mean
 gen rl_episodes_sm_acqmean.jsonl  acquisition  mean "$COUNT"  "$ITERS"
-# R3: real-outcome reward (improvement over incumbent)
-gen rl_episodes_sm_improve.jsonl  improvement  max  "$COUNT"  "$ITERS"
-echo "episodes written to $REPO_ROOT/rl_episodes_sm_{warmup,acqmax,acqmean,improve}.jsonl"
+# R3: real-outcome reward (Pareto hypervolume improvement over the observed front)
+gen rl_episodes_sm_hv.jsonl       hypervolume  max  "$COUNT"  "$ITERS"
+echo "episodes written to $REPO_ROOT/rl_episodes_sm_{warmup,acqmax,acqmean,hv}.jsonl"

--- a/rl/slime_launch/gen_episodes_runs.sh
+++ b/rl/slime_launch/gen_episodes_runs.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Generate the episode prompt-data for every run in the matrix (see RUNS.md).
+# The reward policy + acquisition aggregation are baked into each jsonl here,
+# so the launcher only picks the model. Reads config_real.json for sizes and
+# the real-evaluation kwargs (vina/nn/target), and stamps gp_history_file into
+# each episode's real kwargs so the shared warm GP is wired automatically.
+set -eu
+REPO_ROOT=/mnt/data0/ys/LDM
+CONFIG=$REPO_ROOT/rl/slime_launch/config_real.json
+export PYTHONPATH=$REPO_ROOT/rl:$REPO_ROOT:${PYTHONPATH:-}
+EP=rl.ldm_rl.episodes
+
+read -r COUNT ITERS RES EVALS WARMUP WARMUP_ITERS < <(python3 -c "
+import json;c=json.load(open('$CONFIG'));e=c['episodes'];w=c['warmup']
+print(e['count'],e['iterations'],e['reservoir_size'],e['evaluations_per_round'],w['num_samples'],w['iterations'])")
+
+# real kwargs = config.real_kwargs + gp_history_file
+RK=$(python3 -c "
+import json;c=json.load(open('$CONFIG'))
+rk=dict(c['real_kwargs']);rk['gp_history_file']=c['gp_history_file']
+print(json.dumps(rk))")
+
+gen() {  # gen <out> <reward> <agg> <count> <iters>
+  python3 -m $EP --output "$REPO_ROOT/$1" --task small_molecule --mode real \
+    --count "$4" --iterations "$5" --reservoir-size "$RES" --evaluations-per-round "$EVALS" \
+    --reward "$2" --acquisition-agg "$3" --real-kwargs "$RK"
+}
+
+# warm-up (rollout-only; reward unused, keep acquisition for consistency)
+gen rl_episodes_sm_warmup.jsonl   acquisition  max  "$WARMUP" "$WARMUP_ITERS"
+# R1/R2: acquisition-max
+gen rl_episodes_sm_acqmax.jsonl   acquisition  max  "$COUNT"  "$ITERS"
+# R4: acquisition-mean
+gen rl_episodes_sm_acqmean.jsonl  acquisition  mean "$COUNT"  "$ITERS"
+# R3: real-outcome reward (improvement over incumbent)
+gen rl_episodes_sm_improve.jsonl  improvement  max  "$COUNT"  "$ITERS"
+echo "episodes written to $REPO_ROOT/rl_episodes_sm_{warmup,acqmax,acqmean,improve}.jsonl"

--- a/rl/slime_launch/run_train_real_9b.sh
+++ b/rl/slime_launch/run_train_real_9b.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Real-mode GRPO training for Qwen3.5-9B (hybrid), parameterised for the
+# base-vs-SFT x reward-variant run matrix (see RUNS.md).
+#
+# The reward policy (acquisition-max / acquisition-mean / improvement) is baked
+# into the episode prompt-data by gen_episodes_runs.sh, so this launcher only
+# needs the model + episode file + save dir. Override via env vars:
+#
+#   MODEL_HF   HF checkpoint dir              (default: Qwen3.5-9B base)
+#   MODEL_REF  Megatron torch_dist ref-load   (default: qwen3.5-9B_torch_dist)
+#   EPISODES   prompt-data jsonl              (default: rl_episodes_sm_real.jsonl)
+#   SAVE       checkpoint out dir            (default: rl/qwen3.5-9B_slime_train)
+#   WANDB_KEY  if set -> enables wandb logging
+#   WANDB_PROJECT / WANDB_RUN  wandb names (defaults below)
+set -ex
+export PYTHONUNBUFFERED=1
+
+REPO_ROOT=/mnt/data0/ys/LDM
+SLIME_ROOT=$REPO_ROOT/rl/slime
+MEGATRON_ROOT=/root/megatron-lm
+CONDA_PREFIX=/root/micromamba/envs/slime
+CONFIG=$REPO_ROOT/rl/slime_launch/config_real.json
+
+MODEL_HF=${MODEL_HF:-/mnt/data0/hf_models/models/Qwen3.5-9B}
+MODEL_REF=${MODEL_REF:-$REPO_ROOT/rl/qwen3.5-9B_torch_dist}
+EPISODES=${EPISODES:-$REPO_ROOT/rl_episodes_sm_real.jsonl}
+SAVE=${SAVE:-$REPO_ROOT/rl/qwen3.5-9B_slime_train}
+WANDB_PROJECT=${WANDB_PROJECT:-ldm-sm-rl}
+WANDB_RUN=${WANDB_RUN:-$(basename "$SAVE")}
+
+mkdir -p /root/cudart_block
+touch /root/cudart_block/libcudart.so.13
+
+export PATH=$CONDA_PREFIX/bin:$PATH
+export LD_LIBRARY_PATH=/root/cudart_block:$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
+export PYTHONPATH=$MEGATRON_ROOT:$REPO_ROOT/rl:$REPO_ROOT:$PYTHONPATH
+export CUDA_HOME=$CONDA_PREFIX
+export CUDA_VISIBLE_DEVICES=0,1,2,3
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+
+jq_get() { python3 -c "import json;print(json.load(open('$CONFIG'))['training']['$1'])"; }
+NUM_ROLLOUT=$(jq_get num_rollout)
+ROLLOUT_BATCH=$(jq_get rollout_batch_size)
+N_SAMPLES=$(jq_get n_samples_per_prompt)
+GLOBAL_BATCH=$(jq_get global_batch_size)
+RESP_LEN=$(jq_get rollout_max_response_len)
+MAX_TOKENS=$(jq_get max_tokens_per_gpu)
+TEMPERATURE=$(jq_get rollout_temperature)
+LR=$(jq_get lr)
+SAVE_INTERVAL=$(jq_get save_interval)
+
+cd "$SLIME_ROOT"
+
+# Qwen3.5-9B hybrid (Gated DeltaNet + MTP) architecture args.
+source "$SLIME_ROOT/scripts/models/qwen3.5-9B.sh"   # sets MODEL_ARGS=(...)
+
+CKPT_ARGS=(
+   --hf-checkpoint "$MODEL_HF"
+   --ref-load "$MODEL_REF"
+   --save "$SAVE"
+   --save-interval "$SAVE_INTERVAL"
+)
+
+ROLLOUT_ARGS=(
+   --prompt-data "$EPISODES"
+   --input-key prompt --label-key label
+   --num-rollout "$NUM_ROLLOUT" --rollout-batch-size "$ROLLOUT_BATCH" --n-samples-per-prompt "$N_SAMPLES"
+   --rollout-max-response-len "$RESP_LEN" --rollout-temperature "$TEMPERATURE"
+   --global-batch-size "$GLOBAL_BATCH" --balance-data
+)
+
+# 4 GPUs: TP=2 actor (2 GPUs) + 2 GPUs for the sglang rollout engine.
+PERF_ARGS=(
+   --tensor-model-parallel-size 2
+   --pipeline-model-parallel-size 1 --context-parallel-size 1
+   --use-distributed-optimizer
+   --recompute-granularity full --recompute-method uniform --recompute-num-layers 1
+   --use-dynamic-batch-size --max-tokens-per-gpu "$MAX_TOKENS"
+)
+
+APEX_ARGS=(--no-gradient-accumulation-fusion)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   --use-kl-loss --kl-loss-coef 0.001 --kl-loss-type low_var_kl
+   --eps-clip 0.2 --eps-clip-high 0.28
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam --lr "$LR" --lr-decay-style constant
+   --weight-decay 0.01 --adam-beta1 0.9 --adam-beta2 0.98
+)
+
+SGLANG_ARGS=(
+   --rollout-num-gpus 2 --sglang-mem-fraction-static 0.7
+)
+
+CUSTOM_ARGS=(
+   --custom-generate-function-path ldm_rl.bridge.generate
+   --custom-rm-path ldm_rl.bridge.reward_func
+)
+
+WANDB_ARGS=()
+if [[ -n "${WANDB_KEY:-}" ]]; then
+   WANDB_ARGS=(--use-wandb --wandb-project "$WANDB_PROJECT" --wandb-key "$WANDB_KEY" --wandb-run-name "$WANDB_RUN")
+fi
+
+ray stop --force 2>/dev/null || true
+sleep 3
+ray start --head --node-ip-address 127.0.0.1 --num-gpus 4 --disable-usage-stats
+
+RUNTIME_ENV_JSON="{\"env_vars\": {\"PYTHONPATH\": \"$MEGATRON_ROOT:$REPO_ROOT/rl:$REPO_ROOT\", \"LD_LIBRARY_PATH\": \"/root/cudart_block:$CONDA_PREFIX/lib\", \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\"}}"
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json="$RUNTIME_ENV_JSON" \
+   -- python3 train.py \
+   --actor-num-nodes 1 --actor-num-gpus-per-node 2 --rollout-num-gpus 2 \
+   ${MODEL_ARGS[@]} ${CKPT_ARGS[@]} ${ROLLOUT_ARGS[@]} \
+   ${PERF_ARGS[@]} ${GRPO_ARGS[@]} ${OPTIMIZER_ARGS[@]} \
+   ${APEX_ARGS[@]} ${SGLANG_ARGS[@]} ${CUSTOM_ARGS[@]} ${WANDB_ARGS[@]}


### PR DESCRIPTION
Adds the small-molecule RL (GRPO-on-Slime) run infrastructure and folds in the
fixes surfaced by KangOxford's implementation report (KangOxford PR #2, run on
the GH200/Isambard cluster). Reward/env code is unit-tested (61 passing) and the
real-evaluation path (real Vina + activity + GP/SIR + reward) was smoke-run
end-to-end on CPU.

### Reward / env (`rl/ldm_rl/`)
- `acquisition_agg` (`max` | `mean`) switch for the acquisition reward.
- New **`hypervolume` (ΔHV)** reward: per-round Pareto-front hypervolume
  improvement from real outcomes (2D), with `reward_ref_point` or a per-round
  nadir. Outcome-based, so it does **not** decay to exactly 0 like EHVI — this
  targets the GRPO zero-variance blocker (PR #2 / nb 01).
- Both threaded through `EpisodeSpec` + `episodes.py` CLI; tests added.
- Fixed the obsolete `test_small_molecule_real_mode_raises` (real mode is
  implemented now).

### Launchers & configs (`rl/slime_launch/`)
- `run_train_real_9b.sh` (Qwen3.5-9B hybrid spec, TP=2, 4 GPU, wandb),
  `convert_9b.sh`, `gen_episodes_runs.sh`.
- **PR #2 fixes:**
  - `config_real.json`: `kernel: sk → fp` (`sk` does not finish at production
    scale — ~4000 GP fits, pool → 2600; nb 05); default reward → `hypervolume`.
  - `gen_episodes_runs.sh`: one episode file **per run** (R1–R4), each with its
    own `gp_history_file` + `output_dir` (no cross-run GP sharing; nb 06), warm
    base GP copied per run.
  - `HANDOFF.md` §5 + `RUNS.md`: `--seed-offset` is an `episodes.py` flag
    (regenerate episodes), not a slime/launcher flag.

### Docs
- `HANDOFF.md` (env install, native aarch64/GH200 path, run steps, phased plan),
  `TRAINING_PLAN.md` (goal / models / experiment groups), `RUNS.md` (R1–R4).

### Follow-ups (not in this PR, tracked from PR #2)
- Disable cross-trajectory candidate dedup (runtime-side).
- Merge KangOxford's `bridge.py` chat-template fix.
- Confirm `zero_std/count_0.0` drops with `n=8` + ΔHV before scaling P2.